### PR TITLE
default blockHeight=null to include zero-conf

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function Node (base) {
       // optional blockHeight
       if ('function' === typeof blockHeight) {
         callback = blockHeight
-        blockHeight = 0
+        blockHeight = null
       }
 
       req(base + '/addresses/transactions', { addresses: [].concat(addresses), blockHeight: blockHeight, }, true, self.xhrOptions, callback)


### PR DESCRIPTION
or should blockHeight=0 already include zero-conf, imo blockHeight=0 means you only want confirmed TXs?